### PR TITLE
feat: infer workspace from current directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ packages/test/*
 .vscode
 .yarn
 .env
+.pnpm-debug.log
 **/_isolated_/
 **/_isolated_other_/

--- a/src/params.js
+++ b/src/params.js
@@ -68,14 +68,22 @@ async function getParams() {
   const projectWorkspaces = await getWorkspaces(rootDir);
 
   const workspaceName = (function getWorkspaceName() {
-    const [targetWorkspaceName] = cliParams;
+    let [targetWorkspaceName] = cliParams;
 
-    if (!targetWorkspaceName) {
-      console.log('please provide workspace name or folder');
-      process.exit(1);
+    if (targetWorkspaceName) {
+      if (projectWorkspaces[targetWorkspaceName]) return targetWorkspaceName;
+    } else {
+      targetWorkspaceName = '.';
     }
 
-    if (projectWorkspaces[targetWorkspaceName]) return targetWorkspaceName;
+    if (targetWorkspaceName[0] === '.') {
+      targetWorkspaceName = path.resolve(projectRoot, targetWorkspaceName);
+    }
+
+    // if (!targetWorkspaceName) {
+    //   console.log('please provide workspace name or folder');
+    //   process.exit(1);
+    // }
 
     let workspaceName = Object.keys(projectWorkspaces).find(
       workspace => projectWorkspaces[workspace].location === targetWorkspaceName,


### PR DESCRIPTION
This is just a quick stab at what I'm talking about in #2. I couldn't get tests to run, so I didn't write any. Take a look and see if this is something suitable and I will clean it up a bit. If you can get tests running upstream I'll rebase and write some to cover this.

Not only will this infer the current directory, but it will allow resolution of relative directories too so that you can be inside service-1 and isolate service-2 by doing `npx pnpm-isolate-workspace ../service-2`.