### PR TITLE
Recurse `devDependencies` When Using `--src-less-sub-dev-deps`

### DIFF
--- a/__tests__/full-cycle.test.js
+++ b/__tests__/full-cycle.test.js
@@ -349,7 +349,7 @@ describe('full cycle of isolated', () => {
     ]);
   });
 
-  test('--src-less-sub-dev-deps: should include sub worksapced dev deps', async () => {
+  test('--src-less-sub-dev-deps: should include sub workspaced dev deps', async () => {
     runWithParam('--src-less-sub-dev-deps');
 
     const folder = fse.readdirSync(`${workspaceFolder}/_isolated_/`);
@@ -368,6 +368,7 @@ describe('full cycle of isolated', () => {
       fse.readFileSync(`${workspaceFolder}/_isolated_/workspaces-src-less/packages/workspace-1/package.json`).toString(),
     );
 
+    // With '--src-less-sub-dev-deps', we include the 'devDependencies'
     expect(subWorkspacePackgeJson.devDependencies).toEqual({
       'in-w1-dev-dep-1': '1.0.0',
       'in-w1-dev-dep-2': '2.0.0',
@@ -375,6 +376,26 @@ describe('full cycle of isolated', () => {
       'workspace-13': 'workspace:1.0.0',
       'workspace-15': 'workspace:1.0.0',
     });
+
+    const subWorkspacePackgeJson2 = JSON.parse(
+      fse.readFileSync(`${workspaceFolder}/_isolated_/workspaces-src-less/packages/workspace13/package.json`).toString(),
+    );
+    // Also include the 'devDependencies' of those 'devDependencies'
+    expect(subWorkspacePackgeJson2.devDependencies).toEqual({
+      'in-w13-dev-dep-1': 'workspace:1.0.0',
+      'in-w13-dev-dep-2': 'workspace:1.0.0',
+      'workspace-17': 'workspace:1.0.0',
+    });
+
+    // Make sure we've copied over those workspaces
+    // workspace-1 -> workspace-15 -> workspace-17
+    expect(fse.existsSync(`${workspaceFolder}/_isolated_/workspaces-src-less/packages/workspace17/package.json`)).toEqual(true);
+
+    const subWorkspacePackgeJson3 = JSON.parse(
+      fse.readFileSync(`${workspaceFolder}/_isolated_/workspaces-src-less/packages/workspace17/package.json`).toString(),
+    );
+
+    expect(subWorkspacePackgeJson3.name).toEqual('workspace-17');
 
     // expect(fse.readFileSync(`${workspaceFolder}/_isolated_/yarn.lock`).toString().includes('in-w1-dev-dep-1@1')).toEqual(true);
   });

--- a/__tests__/monoRepo/packages/workspace13/package.json
+++ b/__tests__/monoRepo/packages/workspace13/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "in-w13-dev-dep-1": "workspace:1.0.0",
-    "in-w13-dev-dep-2": "workspace:1.0.0"
+    "in-w13-dev-dep-2": "workspace:1.0.0",
+    "workspace-17": "workspace:1.0.0"
   }
 }

--- a/__tests__/monoRepo/packages/workspace17/package.json
+++ b/__tests__/monoRepo/packages/workspace17/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "workspace-17",
+  "version": "1.1.1",
+  "private": true,
+  "dependencies": {
+  }
+}

--- a/src/params.js
+++ b/src/params.js
@@ -126,7 +126,14 @@ async function getParams() {
       Object.keys(dependencies).forEach(depName => {
         if (projectWorkspaces[depName] && !list.includes(depName)) {
           list.push(depName);
-          recursive(projectWorkspaces[depName].pkgJson.dependencies);
+          if (srcLessSubDev) {
+            recursive({
+              ...projectWorkspaces[depName].pkgJson.dependencies,
+              ...projectWorkspaces[depName].pkgJson.devDependencies,
+            });
+          } else {
+            recursive(projectWorkspaces[depName].pkgJson.dependencies);
+          }
         }
       });
     };


### PR DESCRIPTION
Fixes: #7

I discovered using the `--src-less-sub-dev-deps` flag solves one of my original issues on #7 where the `devDependencies` objects were empty in workspace sub-dependencies. Turning on that flag populates their `devDependencies`.

https://github.com/Madvinking/pnpm-isolate-workspace/blob/93415fe0d2563451534c230612290782196ea6ec/src/index.js#L79-L80

However, if you have a deeply nested workspace sub-dependency while using this flag, its file contents currently won't be copied over to the isolated folder. I think? this patch should resolve that issue by making sure when you're using the `--src-less-sub-dev-deps` flag we recurse into the `devDependencies` of `devDependencies`.

I've included a test case that was previously failing & now passes. All existing tests continue to pass.

Let me know if I'm on the right track here or if any other changes are needed!