### PR TITLE
fix: allow for frozen lock file install

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -257,7 +257,13 @@ async function start() {
             }
           });
         }
-        if (lfData.importers[key].devDependencies) {
+        if (!srcLessSubDev) {
+          console.log('test', key, srcLessSubDev);
+          Object.keys(lfData.importers[key].devDependencies).forEach(depName => {
+            delete lfData.importers[key].specifiers[depName];
+          });
+          lfData.importers[key].devDependencies = {};
+        } else if (lfData.importers[key].devDependencies) {
           Object.keys(lfData.importers[key].devDependencies).forEach(depName => {
             if (relatedWorkspaces.includes(depName)) {
               lfData.importers[key].devDependencies[depName] = `link:${path.relative(


### PR DESCRIPTION
When the srcLessSubDev flag is not set the devDependencies of the workspaces package.json files are being removed. In order to do a --frozen-lockfile installation with pnpm, the pnpm-lock.yaml file needs to remove the devDependencies also so pnpm doesn't complain that their is a mismatch.