### PR TITLE
Prune isolated pnpm locks

### DIFF
--- a/__tests__/full-cycle.test.js
+++ b/__tests__/full-cycle.test.js
@@ -36,7 +36,7 @@ describe('full cycle of isolated', () => {
       'workspaces-src-less-prod',
     ]);
 
-    const worksapceYaml = [
+    const workspaceYaml = [
       'workspaces/packages/workspace-1',
       'workspaces/packages/workspace-2',
       'workspaces/packages/workspace3',
@@ -49,7 +49,7 @@ describe('full cycle of isolated', () => {
 
     const currentYaml = YAML.parse(fse.readFileSync(`${workspaceFolder}/_isolated_/pnpm-workspace.yaml`).toString());
 
-    expect(currentYaml.packages).toEqual(worksapceYaml);
+    expect(currentYaml.packages).toEqual(workspaceYaml);
 
     const listOfAllWorkspaces = [
       'workspace-1',

--- a/__tests__/full-cycle.test.js
+++ b/__tests__/full-cycle.test.js
@@ -10,6 +10,7 @@ let workspaceFolder1 = path.join(__dirname, 'monoRepo/packages/workspace-1');
 const runWithParam = (params = '', workspace = 'root-workspace') => {
   execSync(
     `node ${path.join(__dirname, '../src/index.js')} --project-folder=${path.join(__dirname, 'monoRepo')} ${workspace} ${params}`,
+    { stdio: 'inherit' },
   );
 };
 
@@ -125,6 +126,17 @@ describe('full cycle of isolated', () => {
       'workspace-11': 'link:workspaces/packages/workspace11',
       'workspace-12': 'link:workspaces/packages/workspace12',
     });
+  });
+
+  test('should keep only relevant packages in the isolated lockfile', async () => {
+    runWithParam();
+    const originalLockFile = await lockfile.readWantedLockfile(`${rootFolder}`, 'utf8');
+
+    const isolatedLockFile = await lockfile.readWantedLockfile(`${workspaceFolder}/_isolated_`, 'utf8');
+
+    expect(isolatedLockFile.packages).not.toEqual(originalLockFile.packages);
+    expect(Object.keys(originalLockFile.packages)).toEqual(['/fs-e:/10.0.0', '/is-zero/1.0.0']);
+    expect(Object.keys(isolatedLockFile.packages)).toEqual(['/is-zero/1.0.0']);
   });
 
   test('--include-root-deps: generated in a different output folder', async () => {

--- a/__tests__/monoRepo/packages/workspace-1/package.json
+++ b/__tests__/monoRepo/packages/workspace-1/package.json
@@ -6,7 +6,8 @@
     "workspace-2": "workspace:1.0.0",
     "workspace-3": "workspace:1.0.0",
     "in-w1-dep-1": "1.0.0",
-    "in-w1-dep-2": "2.0.0"
+    "in-w1-dep-2": "2.0.0",
+    "is-zero": "1.0.0"
   },
   "devDependencies": {
     "workspace-11": "workspace:1.0.0",

--- a/__tests__/monoRepo/pnpm-lock.yaml
+++ b/__tests__/monoRepo/pnpm-lock.yaml
@@ -42,11 +42,13 @@ importers:
       "workspace-15": workspace:1.0.0
       "in-w1-dev-dep-1": 1.0.0
       "in-w1-dev-dep-2": 2.0.0
+      "is-zero": 1.0.0
     dependencies:
       "workspace-2": link:../workspace-2
       "workspace-3": link:../workspace3
       "in-w1-dep-1": 1.0.0
       "in-w1-dep-2": 2.0.0
+      "is-zero": 1.0.0
     devDependencies:
       "workspace-11": link:../workspace11
       "workspace-13": link:../workspace12
@@ -60,3 +62,7 @@ packages:
     dependencies:
       "@babel/highlight": 7.13.10
     dev: true
+
+  /is-zero/1.0.0:
+    resolution: {integrity: sha512-1COuYJZC9wyFF8dL06ni3q5eyTzC4Hr+XJfOLNjIiqufpvto5aVNBhqWO1wjwR+fhoBcTbnSDUiBtvEdxHjLiw==}
+    dev: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-isolate-workspace",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "will isolate one pnpm workspace",
   "main": "src/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -36,22 +36,23 @@
     "lint": "eslint --quiet --color ."
   },
   "dependencies": {
-    "@pnpm/lockfile-file": "4.2.3",
     "@pnpm/find-workspace-packages": "3.1.31",
+    "@pnpm/lockfile-file": "4.2.3",
     "@pnpm/logger": "4.0.0",
+    "@pnpm/prune-lockfile": "^4.0.11",
     "fs-extra": "^10.0.0",
     "fs-readdir-recursive": "1.1.0",
     "glob": "7.2.0",
     "yaml": "1.10.2"
   },
   "devDependencies": {
-    "pnpm": "6.24.2",
-    "husky": "7.0.4",
     "eslint": "^8.5.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "husky": "7.0.4",
     "jest": "27.4.5",
     "nodemon": "2.0.15",
+    "pnpm": "6.24.2",
     "prettier": "^2.5.1"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
 
@@ -7,6 +7,7 @@ importers:
       '@pnpm/find-workspace-packages': 3.1.31
       '@pnpm/lockfile-file': 4.2.3
       '@pnpm/logger': 4.0.0
+      '@pnpm/prune-lockfile': ^4.0.11
       eslint: ^8.5.0
       eslint-config-prettier: ^8.3.0
       eslint-plugin-prettier: ^4.0.0
@@ -23,6 +24,7 @@ importers:
       '@pnpm/find-workspace-packages': 3.1.31_@pnpm+logger@4.0.0
       '@pnpm/lockfile-file': 4.2.3_@pnpm+logger@4.0.0
       '@pnpm/logger': 4.0.0
+      '@pnpm/prune-lockfile': 4.0.11
       fs-extra: 10.0.0
       fs-readdir-recursive: 1.1.0
       glob: 7.2.0
@@ -30,7 +32,7 @@ importers:
     devDependencies:
       eslint: 8.5.0
       eslint-config-prettier: 8.3.0_eslint@8.5.0
-      eslint-plugin-prettier: 4.0.0_94e1b6d3ce6ea916847122712570e9ae
+      eslint-plugin-prettier: 4.0.0_stq3nu6on2urnbdrejysk4hjvy
       husky: 7.0.4
       jest: 27.4.5
       nodemon: 2.0.15
@@ -212,6 +214,8 @@ packages:
     resolution: {integrity: sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.13.14
     dev: true
 
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.13.15:
@@ -700,6 +704,11 @@ packages:
     engines: {node: '>=12.17'}
     dev: false
 
+  /@pnpm/constants/6.1.0:
+    resolution: {integrity: sha512-L6AiU3OXv9kjKGTJN9j8n1TeJGDcLX9atQlZvAkthlvbXjvKc5SKNWESc/eXhr5nEfuMWhQhiKHDJCpYejmeCQ==}
+    engines: {node: '>=14.19'}
+    dev: false
+
   /@pnpm/core-loggers/6.1.1_@pnpm+logger@4.0.0:
     resolution: {integrity: sha512-eqdfXu5hP6ZXnMvmQCG1pouItiyNWIwj2JAjfCqTckBpRvmqC7m3QfyxdLSWXe7sJ4sCH+O+6ha8SWhMuSGkHg==}
     engines: {node: '>=12.17'}
@@ -708,6 +717,13 @@ packages:
     dependencies:
       '@pnpm/logger': 4.0.0
       '@pnpm/types': 7.7.1
+    dev: false
+
+  /@pnpm/crypto.base32-hash/1.0.1:
+    resolution: {integrity: sha512-pzAXNn6KxTA3kbcI3iEnYs4vtH51XEVqmK/1EiD18MaPKylhqy8UvMJK3zKG+jeP82cqQbozcTGm4yOQ8i3vNw==}
+    engines: {node: '>=14.6'}
+    dependencies:
+      rfc4648: 1.5.2
     dev: false
 
   /@pnpm/default-reporter/8.5.2_@pnpm+logger@4.0.0:
@@ -800,6 +816,13 @@ packages:
       '@pnpm/types': 7.7.1
     dev: false
 
+  /@pnpm/lockfile-types/4.2.0:
+    resolution: {integrity: sha512-8/t9YrC8VSJgEJv/m1UQMNPHs3Tu4Ow7shpuIDPD5sqjNw3lICB9ybbPlO+6/bkb9/D8QizbBigbVsDybWR9Hw==}
+    engines: {node: '>=14.6'}
+    dependencies:
+      '@pnpm/types': 8.4.0
+    dev: false
+
   /@pnpm/logger/4.0.0:
     resolution: {integrity: sha512-SIShw+k556e7S7tLZFVSIHjCdiVog1qWzcKW2RbLEHPItdisAFVNIe34kYd9fMSswTlSRLS/qRjw3ZblzWmJ9Q==}
     engines: {node: '>=12.17'}
@@ -859,6 +882,17 @@ packages:
       path-absolute: 1.0.1
     dev: false
 
+  /@pnpm/prune-lockfile/4.0.11:
+    resolution: {integrity: sha512-UinjteCGkEBolcvZ6+OSjpK5YMIAQXf8LomoYX3ggV9npyAnXeJ5TTQxC9HC4x9OVDZHk0DSZ+B9JlI27QIX2g==}
+    engines: {node: '>=14.6'}
+    dependencies:
+      '@pnpm/constants': 6.1.0
+      '@pnpm/lockfile-types': 4.2.0
+      '@pnpm/types': 8.4.0
+      dependency-path: 9.2.3
+      ramda: 0.28.0
+    dev: false
+
   /@pnpm/read-project-manifest/2.0.9:
     resolution: {integrity: sha512-6eaa7FYYOTChPAy6f6m2tAPSVg0QvJ/fF19JxTSjH690IttL8yYHFefrTAcfZtGe9RAJfrJL0aO+4N8EoqmHzg==}
     engines: {node: '>=12.17'}
@@ -890,6 +924,11 @@ packages:
   /@pnpm/types/7.7.1:
     resolution: {integrity: sha512-jj13yFemipwFoFfvN89BgQj8DltSRX3ShegsHrjuhOjuaeaxWRZSCMOly7vdZeg2EtfaTrL4HGBgRqdTV5TZiQ==}
     engines: {node: '>=12.17'}
+    dev: false
+
+  /@pnpm/types/8.4.0:
+    resolution: {integrity: sha512-sq/UdSq/jWCpYglw9SFmvR8qzUEi0p2oZIO0AHjkWWQg4Qrolf6DgD0WWmLiEP2WxHjbYeyD3ZzWzQor1+6cvw==}
+    engines: {node: '>=14.6'}
     dev: false
 
   /@pnpm/write-project-manifest/2.0.8:
@@ -982,12 +1021,24 @@ packages:
       '@types/istanbul-lib-report': 3.0.0
     dev: true
 
+  /@types/keyv/3.1.4:
+    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
+    dependencies:
+      '@types/node': 14.14.37
+    dev: true
+
   /@types/node/14.14.37:
     resolution: {integrity: sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==}
     dev: true
 
   /@types/prettier/2.2.3:
     resolution: {integrity: sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==}
+    dev: true
+
+  /@types/responselike/1.0.0:
+    resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
+    dependencies:
+      '@types/node': 14.14.37
     dev: true
 
   /@types/stack-utils/2.0.0:
@@ -1602,10 +1653,16 @@ packages:
     resolution: {integrity: sha512-OD0TZ+B7yP7ZgpJf5K2DIbj3FZvFvxgFUuaqA/V5zTjAtAAXZ1E8bktHxmAGs4x5b7PflqA9LeQ84Og7wYtF7Q==}
     dev: false
 
-  /debug/3.2.7:
+  /debug/3.2.7_supports-color@5.5.0:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
+      supports-color: 5.5.0
     dev: true
 
   /debug/4.3.3:
@@ -1655,6 +1712,16 @@ packages:
   /delayed-stream/1.0.0:
     resolution: {integrity: sha1-3zrhmayt+31ECqrgsp4icrJOxhk=}
     engines: {node: '>=0.4.0'}
+
+  /dependency-path/9.2.3:
+    resolution: {integrity: sha512-P6Nc1ep3SEvi6jXrSzWBZGh8fetwxDgTvqKkR6re3QTAAJ0KwUvYh7QSfAvsP9BYtXZPEYHZtPy44Uato5HbdQ==}
+    engines: {node: '>=14.6'}
+    dependencies:
+      '@pnpm/crypto.base32-hash': 1.0.1
+      '@pnpm/types': 8.4.0
+      encode-registry: 3.0.0
+      semver: 7.3.5
+    dev: false
 
   /detect-indent/6.0.0:
     resolution: {integrity: sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==}
@@ -1717,6 +1784,13 @@ packages:
 
   /emoji-regex/8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  /encode-registry/3.0.0:
+    resolution: {integrity: sha512-2fRYji8K6FwYuQ6EPBKR/J9mcqb7kIoNqt1vGvJr3NrvKfncRiNm00Oxo6gi/YJF8R5Sp2bNFSFdGKTG0rje1Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      mem: 8.1.1
+    dev: false
 
   /end-of-stream/1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
@@ -1783,7 +1857,7 @@ packages:
       eslint: 8.5.0
     dev: true
 
-  /eslint-plugin-prettier/4.0.0_94e1b6d3ce6ea916847122712570e9ae:
+  /eslint-plugin-prettier/4.0.0_stq3nu6on2urnbdrejysk4hjvy:
     resolution: {integrity: sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -2194,6 +2268,8 @@ packages:
     dependencies:
       '@sindresorhus/is': 0.14.0
       '@szmarczak/http-timer': 1.1.2
+      '@types/keyv': 3.1.4
+      '@types/responselike': 1.0.0
       cacheable-request: 6.1.0
       decompress-response: 3.3.0
       duplexer3: 0.1.4
@@ -3346,7 +3422,7 @@ packages:
     requiresBuild: true
     dependencies:
       chokidar: 3.5.2
-      debug: 3.2.7
+      debug: 3.2.7_supports-color@5.5.0
       ignore-by-default: 1.0.1
       minimatch: 3.0.4
       pstree.remy: 1.1.8
@@ -3526,7 +3602,7 @@ packages:
     engines: {node: '>=8'}
 
   /path-name/1.0.0:
-    resolution: {integrity: sha1-jKBjpj3nmC36lXYO2v/RAhRJTyQ=}
+    resolution: {integrity: sha512-/dcAb5vMXH0f51yvMuSUqFpxUcA8JelbRmE5mW/p4CUJxrNgK24IkstnV7ENtg2IDGBOu6izKTG6eilbnbNKWQ==}
     dev: false
 
   /path-parse/1.0.6:
@@ -3675,6 +3751,10 @@ packages:
 
   /ramda/0.27.1:
     resolution: {integrity: sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==}
+    dev: false
+
+  /ramda/0.28.0:
+    resolution: {integrity: sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==}
     dev: false
 
   /rc/1.2.8:
@@ -3838,6 +3918,10 @@ packages:
   /reusify/1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    dev: false
+
+  /rfc4648/1.5.2:
+    resolution: {integrity: sha512-tLOizhR6YGovrEBLatX1sdcuhoSCXddw3mqNVAcKxGJ+J0hFeJ+SjeWCv5UPA/WU3YzWPPuCVYgXBKZUPGpKtg==}
     dev: false
 
   /right-pad/1.0.1:

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const fse = require('fs-extra');
 const readDirSync = require('fs-readdir-recursive');
 const lockfile = require('@pnpm/lockfile-file');
+const { pruneSharedLockfile } = require('@pnpm/prune-lockfile');
 const glob = require('glob');
 const { getParams } = require('./params');
 const YAML = require('yaml');
@@ -276,7 +277,8 @@ async function start() {
         }
       });
 
-    await lockfile.writeWantedLockfile(isolateFolder, lfData);
+    const prunedLockFile = await pruneSharedLockfile(lfData);
+    await lockfile.writeWantedLockfile(isolateFolder, prunedLockFile);
   }
 
   createDestinationFolders();

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ async function start() {
   const {
     rootDir,
     disableRootConfig,
-    rootPacakgeJson,
+    rootPackageJson,
     outputFolder,
     workspaceData,
     prodWorkspaces,
@@ -36,31 +36,31 @@ async function start() {
     srcLessFolderProd,
   } = await getParams();
 
-  const ignorePattterns = ['.', 'package.json', 'node_modules', outputFolder];
+  const ignorePatterns = ['.', 'package.json', 'node_modules', outputFolder];
 
   function createDestinationFolders() {
     if (fs.existsSync(isolateFolder)) fs.rmSync(isolateFolder, { recursive: true });
     fs.mkdirSync(workspacesFolder, { recursive: true });
 
     if (srcFilesExcludeGlob) {
-      const files = glob.sync(srcFilesExcludeGlob, { cwd: workspaceData.location, absolute: true, ignore: ignorePattterns });
+      const files = glob.sync(srcFilesExcludeGlob, { cwd: workspaceData.location, absolute: true, ignore: ignorePatterns });
 
       const filesToCopy = readDirSync(
         workspaceData.location,
-        (name, i, dir) => !ignorePattterns.includes(name) && !files.includes(`${dir}/${name}`),
+        (name, i, dir) => !ignorePatterns.includes(name) && !files.includes(`${dir}/${name}`),
       );
 
       filesToCopy.forEach(file =>
         fse.copySync(path.join(workspaceData.location, file), path.join(isolateFolder, file), { preserveTimestamps: true }),
       );
     } else if (srcFilesIncludeGlob) {
-      const files = glob.sync(srcFilesIncludeGlob, { cwd: workspaceData.location, absolute: true, ignore: ignorePattterns });
+      const files = glob.sync(srcFilesIncludeGlob, { cwd: workspaceData.location, absolute: true, ignore: ignorePatterns });
 
       files.forEach(file =>
         fse.copySync(file, path.join(isolateFolder, path.relative(workspaceData.location, file)), { preserveTimestamps: true }),
       );
     } else if (srcFilesEnable) {
-      const filesToCopy = readDirSync(workspaceData.location, name => !ignorePattterns.includes(name));
+      const filesToCopy = readDirSync(workspaceData.location, name => !ignorePatterns.includes(name));
       filesToCopy.forEach(file =>
         fse.copySync(path.join(workspaceData.location, file), path.join(isolateFolder, file), { preserveTimestamps: true }),
       );
@@ -80,12 +80,12 @@ async function start() {
       fs.writeFileSync(subWorkspace.pkgJsonLocation, JSON.stringify(subWorkspace.pkgJson, null, 2));
 
       const files = workspacesExcludeGlob
-        ? glob.sync(workspacesExcludeGlob, { cwd: subWorkspace.location, absolute: true, ignore: ignorePattterns })
+        ? glob.sync(workspacesExcludeGlob, { cwd: subWorkspace.location, absolute: true, ignore: ignorePatterns })
         : [];
 
       const filesToCopy = readDirSync(
         subWorkspace.location,
-        (name, i, dir) => !ignorePattterns.includes(name) && !files.includes(`${dir}/${name}`),
+        (name, i, dir) => !ignorePatterns.includes(name) && !files.includes(`${dir}/${name}`),
       );
 
       filesToCopy.forEach(file =>
@@ -109,7 +109,7 @@ async function start() {
           flag: 'wx',
         });
         if (srcLessGlob) {
-          const files = glob.sync(srcLessGlob, { cwd: subWorkspace.location, absolute: true, ignore: ignorePattterns });
+          const files = glob.sync(srcLessGlob, { cwd: subWorkspace.location, absolute: true, ignore: ignorePatterns });
 
           files.forEach(file =>
             fse.copySync(file, path.join(subWorkspaceSrcLessFolder, path.relative(subWorkspace.location, file)), {
@@ -135,7 +135,7 @@ async function start() {
         });
 
         if (srcLessProdGlob) {
-          const files = glob.sync(srcLessProdGlob, { cwd: subWorkspace.location, absolute: true, ignore: ignorePattterns });
+          const files = glob.sync(srcLessProdGlob, { cwd: subWorkspace.location, absolute: true, ignore: ignorePatterns });
 
           files.forEach(file =>
             fse.copySync(file, path.join(subWorkspaceSrcLessProdFolder, path.relative(subWorkspace.location, file)), {
@@ -154,18 +154,18 @@ async function start() {
 
     if (includeRootDeps) {
       currentDevDependencies = {
-        ...rootPacakgeJson.devDependencies,
+        ...rootPackageJson.devDependencies,
         ...currentDevDependencies,
       };
     }
 
-    if (!disableRootConfig && rootPacakgeJson.pnpm) {
-      workspaceData.pkgJson.pnpm = rootPacakgeJson.pnpm;
+    if (!disableRootConfig && rootPackageJson.pnpm) {
+      workspaceData.pkgJson.pnpm = rootPackageJson.pnpm;
     }
 
     if (includeRootDeps) {
       workspaceData.pkgJson.dependencies = {
-        ...rootPacakgeJson.dependencies,
+        ...rootPackageJson.dependencies,
         ...workspaceData.pkgJson.dependencies,
       };
     }
@@ -183,11 +183,11 @@ async function start() {
 
   function createWorkspaceYaml() {
     const file = fs.readFileSync(path.join(rootDir, 'pnpm-workspace.yaml'), 'utf8');
-    const worksapceymalFile = YAML.parse(file);
+    const workspaceYamlFile = YAML.parse(file);
 
-    worksapceymalFile.packages = relatedWorkspaces.map(name => projectWorkspaces[name].resolvePath);
+    workspaceYamlFile.packages = relatedWorkspaces.map(name => projectWorkspaces[name].resolvePath);
 
-    fs.writeFileSync(path.join(isolateFolder, 'pnpm-workspace.yaml'), YAML.stringify(worksapceymalFile));
+    fs.writeFileSync(path.join(isolateFolder, 'pnpm-workspace.yaml'), YAML.stringify(workspaceYamlFile));
   }
 
   async function createPnpmLock() {
@@ -198,15 +198,15 @@ async function start() {
       return;
     }
 
-    const importersNames = relatedWorkspaces.map(name => projectWorkspaces[name].reletivePath);
+    const importersNames = relatedWorkspaces.map(name => projectWorkspaces[name].relativePath);
 
     let lfData = await lockfile.readWantedLockfile(rootDir, 'utf8');
 
     Object.keys(lfData.importers).forEach(key => {
-      if (!importersNames.includes(key) && key !== workspaceData.reletivePath && key !== '.') delete lfData.importers[key];
+      if (!importersNames.includes(key) && key !== workspaceData.relativePath && key !== '.') delete lfData.importers[key];
     });
 
-    const targetWorkspace = JSON.parse(JSON.stringify(lfData.importers[workspaceData.reletivePath]));
+    const targetWorkspace = JSON.parse(JSON.stringify(lfData.importers[workspaceData.relativePath]));
 
     lfData.importers['.'] = {
       specifiers: {
@@ -222,7 +222,7 @@ async function start() {
         ...(targetWorkspace.devDependencies || {}),
       },
     };
-    delete lfData.importers[workspaceData.reletivePath];
+    delete lfData.importers[workspaceData.relativePath];
 
     if (lfData.importers['.'].dependencies) {
       Object.keys(lfData.importers['.'].dependencies).forEach(depName => {
@@ -243,7 +243,7 @@ async function start() {
     Object.keys(lfData.importers)
       .filter(n => n !== '.')
       .forEach(currentKey => {
-        const workspaceName = relatedWorkspaces.find(name => projectWorkspaces[name].reletivePath === currentKey);
+        const workspaceName = relatedWorkspaces.find(name => projectWorkspaces[name].relativePath === currentKey);
         const key = `workspaces/${currentKey}`;
         lfData.importers[key] = lfData.importers[currentKey];
         delete lfData.importers[currentKey];

--- a/src/params.js
+++ b/src/params.js
@@ -1,10 +1,10 @@
 const path = require('path');
 const fs = require('fs');
 
-const { default: getallWorkspaces } = require('@pnpm/find-workspace-packages');
+const { default: getAllWorkspaces } = require('@pnpm/find-workspace-packages');
 
 async function getWorkspaces(workspaceRoot) {
-  return (await getallWorkspaces(workspaceRoot)).reduce((acc, { dir, manifest: { name } }) => {
+  return (await getAllWorkspaces(workspaceRoot)).reduce((acc, { dir, manifest: { name } }) => {
     acc[name] = {
       location: dir,
     };

--- a/src/params.js
+++ b/src/params.js
@@ -1,10 +1,10 @@
 const path = require('path');
 const fs = require('fs');
 
-const { default: getallWorksapces } = require('@pnpm/find-workspace-packages');
+const { default: getallWorkspaces } = require('@pnpm/find-workspace-packages');
 
-async function getWorkspaces(worksapceRoot) {
-  return (await getallWorksapces(worksapceRoot)).reduce((acc, { dir, manifest: { name } }) => {
+async function getWorkspaces(workspaceRoot) {
+  return (await getallWorkspaces(workspaceRoot)).reduce((acc, { dir, manifest: { name } }) => {
     acc[name] = {
       location: dir,
     };
@@ -63,7 +63,7 @@ async function getParams() {
 
   const rootDir = getWorkspacesRoot(projectRoot);
 
-  const rootPacakgeJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf-8'));
+  const rootPackageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf-8'));
 
   const projectWorkspaces = await getWorkspaces(rootDir);
 
@@ -91,8 +91,8 @@ async function getParams() {
   })();
 
   for (let key in projectWorkspaces) {
-    projectWorkspaces[key].reletivePath = path.relative(rootDir, projectWorkspaces[key].location);
-    projectWorkspaces[key].resolvePath = path.join('workspaces', projectWorkspaces[key].reletivePath);
+    projectWorkspaces[key].relativePath = path.relative(rootDir, projectWorkspaces[key].location);
+    projectWorkspaces[key].resolvePath = path.join('workspaces', projectWorkspaces[key].relativePath);
     projectWorkspaces[key].pkgJsonLocation = path.join(projectWorkspaces[key].location, 'package.json');
     projectWorkspaces[key].pkgJson = JSON.parse(fs.readFileSync(projectWorkspaces[key].pkgJsonLocation));
     if (projectWorkspaces[key].pkgJson.dependencies && projectWorkspaces[key].pkgJson.dependencies[workspaceName])
@@ -101,7 +101,7 @@ async function getParams() {
     if (projectWorkspaces[key].pkgJson.devDependencies && projectWorkspaces[key].pkgJson.devDependencies[workspaceName])
       delete projectWorkspaces[key].pkgJson.devDependencies[workspaceName];
 
-    if (srcFilesPackageJson) projectWorkspaces[key].inclueFiles = projectWorkspaces[key].pkgJson.files || [];
+    if (srcFilesPackageJson) projectWorkspaces[key].includeFiles = projectWorkspaces[key].pkgJson.files || [];
   }
 
   const workspaceData = projectWorkspaces[workspaceName];
@@ -176,7 +176,7 @@ async function getParams() {
       [--disable-root-config]                disable root package.json pnpm config (like overrides)
 
       // files
-      [--src-files-enable]                   copy all src file of main worksapce to isolate folder
+      [--src-files-enable]                   copy all src file of main workspace to isolate folder
       [--src-files-exclude-glob={value}]     copy src file of main workspace by glob
       [--src-files-include-glob={value}]     copy src file of main workspace by glob
       [--workspaces-exclude-glob={value}]    exclude glob when copy workspaces (default: node_modules and selected output-folder)
@@ -191,7 +191,7 @@ async function getParams() {
 
   return {
     rootDir,
-    rootPacakgeJson,
+    rootPackageJson,
     workspaceName,
     workspaceData,
     prodWorkspaces,


### PR DESCRIPTION
## Description
When generating the dedicated lockfiles there are references to packages that do not belong to the isolated workspace, this PR prunes the lockfile so it only has what it needs.
This is useful when calculating the checksum os an isolated workspace, without the prune every time you add a new package to any workspace the lock will be updated for all isolated workspaces, so the checksum will be updated as well.

[example of diff lock ](https://www.diffchecker.com/f3AoHEiR)pre & post prune

### Extra
Fixed some typos:
- reletivePath -> relativePath
- worksapceymalFile -> workspaceYamlFile
- inclueFiles -> includeFiles
- worksapce -> workspace
- ignorePattterns -> ignorePatterns
- rootPacakgeJson -> rootPackageJson